### PR TITLE
Fixed some test programs, tried to fix test_hyperseti.py

### DIFF
--- a/hyperseti/dedoppler.py
+++ b/hyperseti/dedoppler.py
@@ -9,7 +9,7 @@ from cupyx.scipy.ndimage import uniform_filter1d
 
 from .utils import on_gpu, datwrapper
 from .gpu_kernels import dedoppler_kernel, dedoppler_kurtosis_kernel
-from .filter import apply_boxcar_drift
+from .filter import apply_boxcar_drift, apply_boxcar
 
 #logging
 from .log import logger_group, Logger

--- a/test/test_data_array.py
+++ b/test/test_data_array.py
@@ -1,5 +1,5 @@
 from hyperseti.data_array import from_fil, from_h5
-from .file_defs import voyager_fil, voyager_h5
+from file_defs import voyager_fil, voyager_h5
 import numpy as np
 import cupy as cp
 import pytest

--- a/test/test_datwrapper.py
+++ b/test/test_datwrapper.py
@@ -5,7 +5,7 @@ from hyperseti.dedoppler import dedoppler
 from hyperseti.data_array import DataArray, from_h5, from_fil
 from hyperseti.dimension_scale import DimensionScale, TimeScale
 from hyperseti.utils import datwrapper, on_gpu
-from .file_defs import voyager_fil, voyager_h5
+from file_defs import voyager_fil, voyager_h5
 import pytest
 
 import logbook
@@ -75,6 +75,7 @@ def test_datwrapper_create_data_array():
     metadata = {'test': 0}
     
     dout, mdout = do_create_data_array(data, metadata)
+    print("dout: {}\nmdout: {}".format(dout, mdout))
     assert isinstance(dout, DataArray)
     assert isinstance(mdout, dict)
     assert dout.dims == ('pork', 'noodles')
@@ -85,20 +86,22 @@ def test_datwrapper_create_data_array():
     assert len(dout.attrs) == 1   # Check step/stop are parsed as dimensions
     
     dout2, mdout2 = do_create_data_array(dout)
+    print("dout2: {}\nmdout2: {}".format(dout2, mdout2))
     assert isinstance(dout2, DataArray)
     assert isinstance(mdout2, dict)
     assert dout2.dims == ('pork', 'noodles')
     assert len(dout2.scales.keys()) == 2
-    assert len(mdout2) == 7    # test, pork_start, pork_step, noodles_start, noodles_Step, output_dims, input_dims
+    assert len(mdout2) == 6    # test, pork_start, pork_step, noodles_start, noodles_Step, output_dims //, input_dims
     assert len(dout2.attrs) == 1   # Check step/stop are parsed as dimensions
     
     dout2.attrs['test2'] = 'hi'
     dout3, mdout3 = do_create_data_array(dout2)
+    print("dout3: {}\nmdout3: {}".format(dout3, mdout3))
     assert isinstance(dout3, DataArray)
     assert isinstance(mdout3, dict)
     assert 'test2' in mdout3.keys()
     assert 'test2' in dout3.attrs.keys()
-    assert len(mdout3) == 8    # test, pork_start, pork_step, noodles_start, noodles_Step, output_dims, input_dims
+    assert len(mdout3) == 7    # test, pork_start, pork_step, noodles_start, noodles_Step, output_dims //, input_dims
     assert len(dout3.attrs) == 2   # Check step/stop are parsed as dimensions    
     
 if __name__ == "__main__":

--- a/test/test_kurtosis.py
+++ b/test/test_kurtosis.py
@@ -1,6 +1,6 @@
 from hyperseti.data_array import from_fil, from_h5
 from hyperseti.kurtosis import spectral_kurtosis, sk_flag
-from .file_defs import synthetic_fil, test_fig_dir, voyager_h5
+from file_defs import synthetic_fil, test_fig_dir, voyager_h5
 
 import cupy as cp
 from astropy import units as u
@@ -10,16 +10,15 @@ import os
 
 import logbook
 import hyperseti
-#hyperseti.dedoppler.logger.level = logbook.DEBUG
-#hyperseti.utils.logger.level = logbook.DEBUG
 
 def test_kurtosis():
     h5 = from_h5(voyager_h5)
-    d = spectral_kurtosis(h5)
+    metadata = {'frequency_start': 8421.38671875*u.MHz, 'time_step': 18.253611007999982*u.s, 'frequency_step': -2.7939677238464355e-06*u.MHz}
+    d = spectral_kurtosis(h5, metadata)
     
-    m = sk_flag(h5, n_sigma_upper=3, n_sigma_lower=2, flag_upper=True, flag_lower=True)
-    m = sk_flag(h5, n_sigma_upper=3, n_sigma_lower=2, flag_upper=False, flag_lower=True)
-    m = sk_flag(h5, n_sigma_upper=3, n_sigma_lower=2, flag_upper=True, flag_lower=False)
+    m = sk_flag(h5, metadata, n_sigma_upper=3, n_sigma_lower=2, flag_upper=True, flag_lower=True)
+    m = sk_flag(h5, metadata, n_sigma_upper=3, n_sigma_lower=2, flag_upper=False, flag_lower=True)
+    m = sk_flag(h5, metadata, n_sigma_upper=3, n_sigma_lower=2, flag_upper=True, flag_lower=False)
     
 if __name__ == "__main__":
     test_kurtosis()


### PR DESCRIPTION
As a warm-up for exploring the possibility of producing a dat-writer for the turbo_seti pipeline code, I tried out the test programs which used to work ok.

Modified:
* hyperseti/dedoppler.py - looking in the wrong place for apply_boxcar
* test/test_data_array.py - modest change just so that I could run it with Python as opposed to using pytest due to some environment trouble with pytest (sql database locked??)
* test/test_datwrapper.py - expected length of arrays
* test/test_kurtosis.py - sk_flag calls missing the metadata parameter

Did not come to a conclusion but modified:
* test/test_hyperseti.py

Might be ok but I inserted print-debug statements while wrestling with test_hyperseti.py:
* hyperseti/hits.py - might need some defensive code to prevent crashes on poor input.